### PR TITLE
Use new R2 urls for ext-relay

### DIFF
--- a/src/install-relay.sh
+++ b/src/install-relay.sh
@@ -37,7 +37,7 @@ ensure_source() {
 	# Download the Relay extension.
 
 	if [ ! -d $2 ]; then
-		relay_pkg_url="https://cachewerk.s3.amazonaws.com/relay/$1/${2//+/%2B}.tar.gz"
+		relay_pkg_url="https://builds.r2.relay.so/$1/${2//+/%2B}.tar.gz"
 
 		echo "Downloading: ${relay_pkg_url}"
 		curl -s -S -L $relay_pkg_url | tar xz -C $PLATFORM_CACHE_DIR


### PR DESCRIPTION
Hey!

We're moving from S3 to R2 in the coming months. The old URLs will keep working, but new releases will only be pushed to R2.